### PR TITLE
[CHANGE] improve accessibility of media sources list

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" target-language="de" datatype="plaintext" original="messages" date="2014-05-09T11:53:22Z" product-name="be_defender">
+		<header/>
+		<body>
+            <!-- =================================================== -->
+            <!-- Templates/MediaSource/List    			         -->
+            <!-- =================================================== -->
+  			<trans-unit id="templates.mediaSource.list.title">
+                <source>Media sources and copyright hints</source>
+                <target>Bildquellen und Copyright-Hinweise</target>
+            </trans-unit>
+        </body>
+	</file>
+</xliff>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+	<file source-language="en" datatype="plaintext" original="messages" date="2014-11-07T15:00:08Z" product-name="be_defender">
+		<header/>
+		<body>
+            <!-- =================================================== -->
+            <!-- Templates/MediaSource/List    			         -->
+            <!-- =================================================== -->
+  			<trans-unit id="templates.mediaSource.list.title">
+                <source>Media sources and copyright hints</source>
+            </trans-unit>
+        </body>
+	</file>
+</xliff>

--- a/Resources/Private/Templates/MediaSource/List.html
+++ b/Resources/Private/Templates/MediaSource/List.html
@@ -4,12 +4,17 @@
 	<f:layout name="Default" />
 
 	<f:section name="main">
-		<f:if condition="{mediaSources}">
-            <ul class="media-source-list" role="contentinfo">
-                <f:for each="{mediaSources}" as="mediaSource">
-                    <f:render partial="MediaSource" arguments="{mediaSource: mediaSource}"  />
-                </f:for>
-            </ul>
-		</f:if>
+        <section aria-labelledby="media-sources-list-title">
+            <f:if condition="{mediaSources}">
+                <div id="media-source-list-title" class="sr-only">
+                    <f:translate key="templates.mediaSource.list.title" />
+                </div>
+                <ul class="media-source-list">
+                    <f:for each="{mediaSources}" as="mediaSource">
+                        <f:render partial="MediaSource" arguments="{mediaSource: mediaSource}"  />
+                    </f:for>
+                </ul>
+            </f:if>
+        </section>
 	</f:section>
 </html>


### PR DESCRIPTION
This is a suggestion to improve accessibility of the media source list, as the role="contentinfo" was a little misleading as only the media sources have been listed and general information on the content may have been placed in a dedicated element in the footer. To prevent possibly multiple sections of the same role, I decided to wrap it into a section with a label, hidden to no non-screenreaders.

I opted against a heading element as it could not be verified, if and which heading elements may occur before. Using a hidden element <div> and avoiding the use of  role="heading" prevents any interruptions to the flow of the headline hierarchy. 